### PR TITLE
refactor: replace issubclass datetime handling with coerce_to_iso8601…

### DIFF
--- a/canopy/helpers.py
+++ b/canopy/helpers.py
@@ -1,26 +1,25 @@
 import re
+from datetime import date, datetime
 
 
-def _validate_enum(value, acceptable_values):
-    if not isinstance(value, list):
-        if value in acceptable_values:
-            return value
-        else:
-            raise ValueError(f"{value} not in {acceptable_values}")
-    else:
-        for v in value:
-            if v in acceptable_values:
-                return value
-            else:
-                raise ValueError(f"{value} not in {acceptable_values}")
+def _validate_enum(value: str | list[str], acceptable_values: list[str]) -> str | list[str]:
+    values = value if isinstance(value, list) else [value]
+    for v in values:
+        if v not in acceptable_values:
+            raise ValueError(f"{v!r} not in {acceptable_values}")
+    return value
 
 
-def _validate_iso8601_string(value):
+def _validate_iso8601_string(value: str) -> str:
     """Return the value or raise a ValueError if it is not a string in ISO8601 format."""
-    ISO8601_REGEX = (
-        r"(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})([+-](\d{2})\:(\d{2})|Z)"
-    )
+    ISO8601_REGEX = r"(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2})([+-](\d{2})\:(\d{2})|Z)"
     if re.match(ISO8601_REGEX, value):
         return value
-    else:
-        raise ValueError(f"{value} must be in ISO8601 format.")
+    raise ValueError(f"{value!r} must be in ISO8601 format.")
+
+
+def coerce_to_iso8601(value: str | date | datetime) -> str:
+    """Coerce a string, date, or datetime to an ISO8601 formatted string."""
+    if isinstance(value, str):
+        return _validate_iso8601_string(value)
+    return value.strftime("%Y-%m-%dT%H:%M:%S+00:00")

--- a/canopy/templates/canopy_api.py.jinja2
+++ b/canopy/templates/canopy_api.py.jinja2
@@ -4,10 +4,7 @@
 _validate_enum({{param.name|fix_param_name}}, {{enum_values(param.enum)}})
 {% endif %}
 {% if param.type|lower == "datetime" %}
-if issubclass({{param.name|fix_param_name}}.__class__, str):
-    {{param.name|fix_param_name}} = _validate_iso8601_string({{param.name|fix_param_name}})
-elif issubclass({{param.name|fix_param_name}}.__class__, date) or issubclass({{param.name|fix_param_name}}.__class__, datetime):
-    {{param.name|fix_param_name}} = {{param.name|fix_param_name}}.strftime('%Y-%m-%dT%H:%M:%S+00:00')
+{{param.name|fix_param_name}} = coerce_to_iso8601({{param.name|fix_param_name}})
 {% endif %}
 {% if param.paramType == "form" %}
 data["{{param.name}}"] = {{param.name|fix_param_name}}
@@ -23,9 +20,9 @@ params["{{param.name}}"] = {{param.name|fix_param_name}}
 This API client was generated using a template. Make sure this code is valid before using it.
 """
 from datetime import date, datetime
-from canopy.helpers import _validate_enum, _validate_iso8601_string
+from canopy.helpers import _validate_enum, coerce_to_iso8601
 
-class {{api_name}}(object):
+class {{api_name}}:
     """{{api_name}} API Version {{spec.apiVersion|default("1.0")}}."""
 
     def __init__(self, client):

--- a/canopy/templates/canopy_api_async.py.jinja2
+++ b/canopy/templates/canopy_api_async.py.jinja2
@@ -4,10 +4,7 @@
 _validate_enum({{param.name|fix_param_name}}, {{enum_values(param.enum)}})
 {% endif %}
 {% if param.type|lower == "datetime" %}
-if issubclass({{param.name|fix_param_name}}.__class__, str):
-    {{param.name|fix_param_name}} = _validate_iso8601_string({{param.name|fix_param_name}})
-elif issubclass({{param.name|fix_param_name}}.__class__, date) or issubclass({{param.name|fix_param_name}}.__class__, datetime):
-    {{param.name|fix_param_name}} = {{param.name|fix_param_name}}.strftime('%Y-%m-%dT%H:%M:%S+00:00')
+{{param.name|fix_param_name}} = coerce_to_iso8601({{param.name|fix_param_name}})
 {% endif %}
 {% if param.paramType == "form" %}
 data["{{param.name}}"] = {{param.name|fix_param_name}}
@@ -23,9 +20,9 @@ params["{{param.name}}"] = {{param.name|fix_param_name}}
 This API client was generated using a template. Make sure this code is valid before using it.
 """
 from datetime import date, datetime
-from canopy.helpers import _validate_enum, _validate_iso8601_string
+from canopy.helpers import _validate_enum, coerce_to_iso8601
 
-class {{api_name}}Async(object):
+class {{api_name}}Async:
     """{{api_name}} API Version {{spec.apiVersion|default("1.0")}}."""
 
     def __init__(self, client):


### PR DESCRIPTION
# PR 3 — Template Cleanup & Helper Modernization

## Summary

Cleans up the Jinja2 templates and `helpers.py` — replacing the verbose `issubclass` datetime handling with a unified `coerce_to_iso8601` helper, removing `object` base class inheritance from generated classes, and adding type annotations to helpers.

---

## Changes

### `canopy/helpers.py`
- Added `coerce_to_iso8601()` — unifies datetime coercion logic that was previously duplicated inline in both templates; accepts `str`, `date`, or `datetime` and returns an ISO8601 string
- Added type annotations to all functions
- Fixed a logic bug in `_validate_enum` — previously returned early on the first matching value in a list instead of checking all values

### `canopy/templates/canopy_api.py.jinja2`
- Replaced 4-line `issubclass(x.__class__, ...)` datetime block with a single `coerce_to_iso8601()` call
- Updated import line to use `coerce_to_iso8601` instead of `_validate_iso8601_string`
- Removed `(object)` base class from generated class definition

### `canopy/templates/canopy_api_async.py.jinja2`
- Same changes as `canopy_api.py.jinja2`

---

## Notes

- No changes to `canopy.py`, `canvas_api_builder.py`, or `pyproject.toml`
- No breaking changes to any generated API method signatures
- Existing generated API modules will continue to work but should be regenerated to pick up the cleaner output
- `_validate_iso8601_string` remains in `helpers.py` as it is still used by `coerce_to_iso8601` internally