### PR TITLE
ci: add GitHub Actions workflow for lint and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dev dependencies
+        run: uv sync --extra dev
+
+      - name: Run ruff check
+        run: uv run ruff check .
+
+      - name: Run ruff format check
+        run: uv run ruff format . --check
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dev and builder dependencies
+        run: uv sync --extra dev --extra builder
+
+      - name: Run pytest
+        run: uv run pytest tests/ -v

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,58 @@
+"""Tests for canopy/helpers.py"""
+
+from datetime import date, datetime
+
+import pytest
+
+from canopy.helpers import _validate_enum, _validate_iso8601_string, coerce_to_iso8601
+
+
+class TestCoerceToIso8601:
+    def test_valid_string_passthrough(self):
+        value = "2024-01-15T10:30:00Z"
+        assert coerce_to_iso8601(value) == value
+
+    def test_invalid_string_raises(self):
+        with pytest.raises(ValueError):
+            coerce_to_iso8601("not-a-date")
+
+    def test_date_object(self):
+        result = coerce_to_iso8601(date(2024, 1, 15))
+        assert result == "2024-01-15T00:00:00+00:00"
+
+    def test_datetime_object(self):
+        result = coerce_to_iso8601(datetime(2024, 1, 15, 10, 30, 0))
+        assert result == "2024-01-15T10:30:00+00:00"
+
+    def test_string_with_offset(self):
+        value = "2024-01-15T10:30:00+07:00"
+        assert coerce_to_iso8601(value) == value
+
+
+class TestValidateEnum:
+    def test_valid_single_value(self):
+        assert _validate_enum("position", ["position", "name", "due_at"]) == "position"
+
+    def test_invalid_single_value_raises(self):
+        with pytest.raises(ValueError):
+            _validate_enum("invalid", ["position", "name", "due_at"])
+
+    def test_valid_list(self):
+        result = _validate_enum(["position", "name"], ["position", "name", "due_at"])
+        assert result == ["position", "name"]
+
+    def test_invalid_list_raises(self):
+        with pytest.raises(ValueError):
+            _validate_enum(["position", "invalid"], ["position", "name", "due_at"])
+
+
+class TestValidateIso8601String:
+    def test_valid_utc(self):
+        assert _validate_iso8601_string("2024-01-15T10:30:00Z") == "2024-01-15T10:30:00Z"
+
+    def test_valid_offset(self):
+        assert _validate_iso8601_string("2024-01-15T10:30:00+07:00") == "2024-01-15T10:30:00+07:00"
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError):
+            _validate_iso8601_string("2024-01-15")

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,101 @@
+"""Tests for Jinja2 template output correctness."""
+
+import pytest
+
+from canopy.scripts.canvas_api_builder import get_jinja_env
+
+MINIMAL_SPEC = {
+    "apiVersion": "1.0",
+    "apis": [
+        {
+            "path": "/courses/{course_id}/assignments",
+            "operations": [
+                {
+                    "nickname": "list_assignments",
+                    "summary": "List assignments for a course",
+                    "notes": "Returns paginated list.",
+                    "method": "GET",
+                    "type": "array",
+                    "parameters": [
+                        {
+                            "name": "course_id",
+                            "paramType": "path",
+                            "required": True,
+                            "type": "integer",
+                        },
+                        {
+                            "name": "due_at",
+                            "paramType": "query",
+                            "required": False,
+                            "type": "DateTime",
+                        },
+                        {
+                            "name": "order_by",
+                            "paramType": "query",
+                            "required": False,
+                            "type": "string",
+                            "enum": ["position", "name", "due_at"],
+                        },
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+
+@pytest.fixture
+def sync_output():
+    env = get_jinja_env()
+    template = env.get_template("canopy_api.py.jinja2")
+    return template.render(spec=MINIMAL_SPEC, api_name="Assignments", api_file_name="assignments")
+
+
+@pytest.fixture
+def async_output():
+    env = get_jinja_env()
+    template = env.get_template("canopy_api_async.py.jinja2")
+    return template.render(
+        spec=MINIMAL_SPEC, api_name="Assignments", api_file_name="assignments_async"
+    )
+
+
+class TestSyncTemplate:
+    def test_no_object_base_class(self, sync_output):
+        assert "class Assignments(object)" not in sync_output
+        assert "class Assignments:" in sync_output
+
+    def test_correct_import(self, sync_output):
+        assert "from canopy.helpers import _validate_enum, coerce_to_iso8601" in sync_output
+        assert "_validate_iso8601_string" not in sync_output
+
+    def test_no_issubclass(self, sync_output):
+        assert "issubclass" not in sync_output
+
+    def test_coerce_to_iso8601_used(self, sync_output):
+        assert "coerce_to_iso8601(due_at)" in sync_output
+
+    def test_validate_enum_used(self, sync_output):
+        assert '_validate_enum(order_by, ["position", "name", "due_at"])' in sync_output
+
+    def test_generated_code_is_valid_python(self, sync_output):
+        compile(sync_output, "<generated>", "exec")
+
+
+class TestAsyncTemplate:
+    def test_no_object_base_class(self, async_output):
+        assert "class AssignmentsAsync(object)" not in async_output
+        assert "class AssignmentsAsync:" in async_output
+
+    def test_correct_import(self, async_output):
+        assert "from canopy.helpers import _validate_enum, coerce_to_iso8601" in async_output
+        assert "_validate_iso8601_string" not in async_output
+
+    def test_no_issubclass(self, async_output):
+        assert "issubclass" not in async_output
+
+    def test_async_def_present(self, async_output):
+        assert "async def list_assignments" in async_output
+
+    def test_generated_code_is_valid_python(self, async_output):
+        compile(async_output, "<generated>", "exec")


### PR DESCRIPTION
# PR 5 — CI: GitHub Actions

## Summary

Adds a GitHub Actions workflow that runs on every push and pull request to `main`, with separate jobs for linting and testing.

---

## Changes

### `.github/workflows/ci.yml`
- **`lint` job** — runs `ruff check` and `ruff format --check`
- **`test` job** — runs `pytest tests/ -v`
- Both jobs use `astral-sh/setup-uv` and Python 3.12
- Jobs run in parallel for faster feedback
- Test job installs both `dev` and `builder` extras since the template tests require `canvas_api_builder`

### `tests/`
- `tests/__init__.py` — makes tests a proper package
- `tests/test_helpers.py` — tests for `coerce_to_iso8601`, `_validate_enum`, and `_validate_iso8601_string`
- `tests/test_templates.py` — tests for generated sync and async template output

---

## Notes

- 23 tests, all passing locally
- `builder` extra is required in the test job because `test_templates.py` imports from `canvas_api_builder` which depends on `click` and `jinja2`
- Future tests for `canopy.py` (mocking httpx) can be added to `tests/` and will be picked up automatically